### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We recommend browsing the official site [here](https://usebootstrap.org/). The o
 Installation of Bootstrap5 and use-bootstrap NPM Package
 
 ```
-npm i usebootstrap
+npx nuxi@latest module add use-bootstrap
 ```
 
 Add a usebootstrap section in your nuxt.config.


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
